### PR TITLE
Enumerate + uint8_t = union

### DIFF
--- a/Data.hpp
+++ b/Data.hpp
@@ -12,14 +12,40 @@
 # define CURSOR_LEFT "\033[D"
 
 // Palette Type
-# define GRAY 0
-# define RGB 1
-# define PURPLE 2
+//# define GRAY 0
+//# define RGB 1
+//# define PURPLE 2
 
 // Button no.
-# define FIRST 0
-# define SECOND 1
-# define THIRD 2
+//# define FIRST 0
+//# define SECOND 1
+//# define THIRD 2
+
+//enum	paletteType
+//{
+//	GRAY = 0,
+//	RGB,
+//	PURPLE
+//};
+//
+//union	PaletteType
+//{
+//	uint8_t				raw;
+//	enum paletteType	enumerate;
+//};
+
+enum	option
+{
+	FIRST = 0,
+	SECOND,
+	THIRD
+};
+
+union	Option
+{
+	uint8_t		raw;
+	enum option	enumerate;
+};
 
 enum	optionDisplayMode
 {
@@ -32,25 +58,25 @@ enum	optionDisplayMode
 
 typedef struct _Data
 {
-	uint16_t		magic_number; // BM, SJ
+	uint16_t	magic_number; // BM, SJ
 	// image 기준.
-	uint32_t		image_width;
-	uint32_t		image_height;
+	uint32_t	image_width;
+	uint32_t	image_height;
 
 	// terminal 기준.
-	uint32_t		terminal_width;
-	uint32_t		terminal_height;
+	uint32_t	terminal_width;
+	uint32_t	terminal_height;
 
-	std::string		filename;
+	std::string	filename;
 
-	uint8_t			palette_type;
-	uint8_t			color_index[5];
-	uint8_t			bgcolor;
+	uint8_t		bgcolor;
+	enum option	palette_type;
+	uint8_t		color_index[5];
 
-	uint32_t		ti;
-	uint32_t		tj;
+	uint32_t	ti;
+	uint32_t	tj;
 
-	uint8_t**		terminal_pixel_data;
+	uint8_t**	terminal_pixel_data;
 } Data;
 
 #endif

--- a/Data.hpp
+++ b/Data.hpp
@@ -11,29 +11,6 @@
 # define CURSOR_RIGHT "\033[C"
 # define CURSOR_LEFT "\033[D"
 
-// Palette Type
-//# define GRAY 0
-//# define RGB 1
-//# define PURPLE 2
-
-// Button no.
-//# define FIRST 0
-//# define SECOND 1
-//# define THIRD 2
-
-//enum	paletteType
-//{
-//	GRAY = 0,
-//	RGB,
-//	PURPLE
-//};
-//
-//union	PaletteType
-//{
-//	uint8_t				raw;
-//	enum paletteType	enumerate;
-//};
-
 enum	option
 {
 	FIRST = 0,

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 NAME=bmp_serializer
 CXX=c++
-CXXFLAGS=-Wall -Wextra -Werror -Wpedantic -std=c++98
+CXXFLAGS=-Wall -Wextra -Werror -Wpedantic -std=c++98 -fshort-enums
 CPPFLAGS=-MMD -MP -MF $(DEPS_DIR)/$*.d
 
 RM=rm -fr

--- a/Serializer.hpp
+++ b/Serializer.hpp
@@ -18,9 +18,9 @@ class	Serializer
 		static void			setRawMode(bool enable);
 		static void			clearPixel(Data& data);
 		static uint8_t		checkEscape(char* cptr);
-		static uint32_t		getPixel(Data& data);
-		static void			displayOption(Data& data, enum optionDisplayMode mode, int8_t option);
-		static uint8_t		chooseOption(Data& data, enum optionDisplayMode mode, uint8_t button_number);
+		static uint8_t		getPixel(Data& data);
+		static void			displayOption(Data& data, enum optionDisplayMode mode, union Option option);
+		static union Option	chooseOption(Data& data, enum optionDisplayMode mode, uint8_t button_number);
 		static void			setColorIndex(Data& data);
 		static uint32_t		setConfig(Data& data);
 		static void			initScreen(Data& data);
@@ -31,7 +31,7 @@ class	Serializer
 		static Data*		deserialize(uintptr_t raw);
 		static uint32_t		reloadTerminalData(Data* data);
 
-		static uint8_t		chooseSD();
+		static union Option	chooseSD();
 };
 
 void	freeTerminalData(Data* data);

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int	main(void)
 {
 	// serialize
 	Data*	data;
-	if (Serializer::chooseSD() == FIRST)
+	if (Serializer::chooseSD().enumerate == FIRST)
 	{
 		data = Serializer::generateImgData();
 


### PR DESCRIPTION
```cpp
enum	option
{
	FIRST = 0,
	SECOND,
	THIRD
};

union	Option
{
	uint8_t		raw;
	enum option	enumerate;
};
```
## 변경 사항
1. `static_cast`를 사용하지 않으면서 정수 데이터를 산술 연산과 조건 판단이라는 두가지 상황에 따라 다르게 해석할 수 있도록 `union`을 사용했다.
    - `enum option e = (FIRST + 1) % button number;` 과 같이 산술 연산의 결과를 열거형 타입의 변수에 할당하는 것은 허용되지 않는다. 타입 안정성 때문에 `static_cast`를 사용하여 명시적으로 변환해야 하는데 이를 사용할 수 없기 때문에 연산이 들어갈 때는 `uint8_t` 타입을 사용하기로 했다.
2. 컴파일러 옵션에 `-fshort-enums`를 추가하여 `enum option`이 `uint8_t`와 동일한 크기를 갖도록 보장했다.
```cpp
if (c == 'C')
{
	option.raw = (option.raw + 1) % button_number;
}
else if (c == 'D')
{
	option.raw = (option.raw - 1 + button_number) % button_number;
}
```
```cpp
if (option.enumerate == FIRST)
{
	// 커서 위치 복원
	std::cout << "\033[" << data.tj + 2 << ";" << data.ti + 2 << "H";
}
else if (option.enumerate == THIRD)
{
	data.magic_number = 0x4A53;
	data.filename += "_draft";
	option.enumerate = SECOND;
}

```